### PR TITLE
fix: resolve proxy routing causing 404 for chat endpoint

### DIFF
--- a/server/python_bot/app.py
+++ b/server/python_bot/app.py
@@ -135,6 +135,7 @@ bot = SubManagerBot(retriever)
 
 
 # ── API Routes ────────────────────────────────────────────────────────────────
+@app.route('/', methods=['POST'])
 @app.route('/api/chat', methods=['POST'])
 def chat():
     data = request.json

--- a/server/server.js
+++ b/server/server.js
@@ -51,6 +51,14 @@ if (trustProxyConfig !== undefined) {
   app.set('trust proxy', 1);
 }
 
+// Proxy /api/chat to the Python Bot running on localhost:5001
+// MUST be registered before express.json() to prevent body streams from being consumed
+const { createProxyMiddleware } = require('http-proxy-middleware');
+app.use('/api/chat', createProxyMiddleware({ 
+  target: 'http://localhost:5001', 
+  changeOrigin: true 
+}));
+
 // Middleware
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
@@ -83,12 +91,7 @@ app.get('/api/health', requireLogin, (req, res) => {
 const apiRouter = express.Router();
 const protectedApiRouter = express.Router();
 
-// Proxy /api/chat to the Python Bot running on localhost:5001
-const { createProxyMiddleware } = require('http-proxy-middleware');
-app.use('/api/chat', createProxyMiddleware({ 
-  target: 'http://localhost:5001', 
-  changeOrigin: true 
-}));
+// Proxy middleware initialized above to avoid body consumption issues
 
 // Auth routes (no login required)
 app.use('/api/auth', createAuthRoutes(db));


### PR DESCRIPTION
## Problem

The chat endpoint (`POST /api/chat`) was returning **404 errors** due to incorrect proxy middleware ordering in `server.js`. The `createProxyMiddleware` was registered **after** `express.json()`, which caused the request body stream to be consumed before the proxy could forward it to the Python bot running on `localhost:5001`.

## Solution

This PR fixes the issue by reordering the middleware initialization so that the proxy middleware is registered **before** `express.json()`, ensuring the request body is properly forwarded to the backend.

## Changes

### 1. `server/server.js` (9 additions, 6 deletions)
- **Moved** `createProxyMiddleware` registration from line 86 (after `express.json()`) to line 54 (before `express.json()`)
- Added a comment explaining that the proxy must be registered before body parsers to prevent body stream consumption
- Updated the comment at the old location to note that proxy middleware is now initialized above

### 2. `server/python_bot/app.py` (1 addition)
- Added `@app.route('/', methods=['POST'])` alongside the existing `/api/chat` route for additional flexibility in request routing

## Files Changed

| File | Changes |
|------|---------|
| `server/server.js` | Reordered proxy middleware + comments |
| `server/python_bot/app.py` | Added root POST route |

## Testing Checklist

- [ ] Verify `POST /api/chat` no longer returns 404
- [ ] Confirm chat messages are properly forwarded to Python bot on port 5001
- [ ] Test request body is intact (no truncation or parsing errors)
- [ ] Verify the root `/` POST route on Python bot responds correctly
- [ ] Run health check endpoint to confirm server startup

## Related

- Fixes the 404 error on chat endpoint
- Commit: `1c028f3`